### PR TITLE
fix: spelling

### DIFF
--- a/pkg/cmd/apikeys/create/create.go
+++ b/pkg/cmd/apikeys/create/create.go
@@ -42,11 +42,11 @@ func NewCreateCmd(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		Short: "Create a new API key",
 		Long:  `Create a new API key with the provided parameters.`,
 		Example: heredoc.Doc(`
-			# Create a new API key targetting the index "foo", with the "search" and "browse" ACL and a description
-			$ algolia create --indices foo --acl search,browse --description "Search & Browse API Key"
+			# Create a new API key targeting the index "foo", with the "search" and "browse" ACL and a description
+			$ algolia apikeys create --indices foo --acl search,browse --description "Search & Browse API Key"
 
-			# Create a new API key targetting the indexes "foo" and "bar", with the "http://foo.com" refferer, with a validity of 1 hour and a description
-			$ algolia create -i foo,bar --acl search -r "http://foo.com" --u 1h -d "Search-only API Key for foo & bar"
+			# Create a new API key targeting the indices "foo" and "bar", with the "http://foo.com" referer, with a validity of 1 hour and a description
+			$ algolia apikeys create -i foo,bar --acl search -r "http://foo.com" --u 1h -d "Search-only API Key for foo & bar"
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runF != nil {

--- a/pkg/cmd/apikeys/delete/delete.go
+++ b/pkg/cmd/apikeys/delete/delete.go
@@ -73,7 +73,7 @@ func runDeleteCmd(opts *DeleteOptions) error {
 
 	if opts.DoConfirm {
 		var confirmed bool
-		err = prompt.Confirm(fmt.Sprintf("Delete the following API Key: %s?", opts.APIKey), &confirmed)
+		err = prompt.Confirm(fmt.Sprintf("Delete the following API key: %s?", opts.APIKey), &confirmed)
 		if err != nil {
 			return fmt.Errorf("failed to prompt: %w", err)
 		}

--- a/pkg/cmd/indices/copy/copy.go
+++ b/pkg/cmd/indices/copy/copy.go
@@ -51,13 +51,13 @@ func NewCopyCmd(f *cmdutil.Factory, runF func(*CopyOptions) error) *cobra.Comman
 		`),
 		Example: heredoc.Doc(`
 			# Copy the records, settings, synonyms and rules from the "TEST_PRODUCTS_1" index to the "TEST_PRODUCTS_2" index
-			$ algolia index copy TEST_PRODUCTS DEV_PRODUCTS
+			$ algolia indices copy TEST_PRODUCTS DEV_PRODUCTS
 
 			# Copy only the synonyms of the "TEST_PRODUCTS_1" to the "TEST_PRODUCTS_2" index
-			$ algolia index copy TEST_PRODUCTS DEV_PRODUCTS --scope synonyms
+			$ algolia indices copy TEST_PRODUCTS DEV_PRODUCTS --scope synonyms
 
 			# Copy the synonyms and rules of the index "TEST_PRODUCTS_1" to the "TEST_PRODUCTS_2" index
-			$ algolia index copy TEST_PRODUCTS DEV_PRODUCTS --scope synonyms,rules
+			$ algolia indices copy TEST_PRODUCTS DEV_PRODUCTS --scope synonyms,rules
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.SourceIndex = args[0]

--- a/pkg/cmd/indices/list/list.go
+++ b/pkg/cmd/indices/list/list.go
@@ -38,7 +38,7 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "List indices",
 		Example: heredoc.Doc(`
 			# List indices
-			$ algolia index list
+			$ algolia indices list
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runListCmd(opts)

--- a/pkg/cmd/objects/objects.go
+++ b/pkg/cmd/objects/objects.go
@@ -13,7 +13,7 @@ import (
 func NewObjectsCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "objects",
-		Short: "Manage your indices objects",
+		Short: "Manage your indices' objects",
 	}
 
 	cmd.AddCommand(browse.NewBrowseCmd(f))

--- a/pkg/cmd/rules/browse/browse.go
+++ b/pkg/cmd/rules/browse/browse.go
@@ -40,10 +40,10 @@ func NewBrowseCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:             "List all the rules of an index",
 		Example: heredoc.Doc(`
 			# List all the rules of the "TEST_PRODUCTS_1" index
-			$ algolia rule browse TEST_PRODUCTS_1
+			$ algolia rules browse TEST_PRODUCTS_1
 
 			# List all the rules of the "TEST_PRODUCTS_1" index and save them to a 'rules.ndjson' file
-			$ algolia rule browse TEST_PRODUCTS_1 --json > rules.ndjson
+			$ algolia rules browse TEST_PRODUCTS_1 --json > rules.ndjson
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/rules/import/import.go
+++ b/pkg/cmd/rules/import/import.go
@@ -45,7 +45,7 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		`),
 		Example: heredoc.Doc(`
 			# Import rules from the "rules.ndjson" file to the "TEST_PRODUCTS_1" index
-			$ algolia import TEST_PRODUCTS_1 -F rules.ndjson
+			$ algolia rules import TEST_PRODUCTS_1 -F rules.ndjson
 
 			# Import rules from the standard input to the "TEST_PRODUCTS_1" index
 			$ cat rules.ndjson | algolia rules import TEST_PRODUCTS_1 -F -

--- a/pkg/cmd/rules/import/import_test.go
+++ b/pkg/cmd/rules/import/import_test.go
@@ -7,12 +7,107 @@ import (
 	"testing"
 
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/pkg/iostreams"
 	"github.com/algolia/cli/test"
 )
+
+func TestNewImportCmd(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "rules.ndjson")
+	_ = ioutil.WriteFile(file, []byte("{\"objectID\":\"test\"}"), 0600)
+
+	tests := []struct {
+		name      string
+		tty       bool
+		cli       string
+		wantsErr  bool
+		wantsOpts ImportOptions
+	}{
+		{
+			name:     "no file specified",
+			cli:      "index",
+			wantsErr: true,
+		},
+		{
+			name:     "file not found",
+			cli:      "index --file not-found",
+			wantsErr: true,
+		},
+		{
+			name: "file specified",
+			cli:  fmt.Sprintf("index -F %s", file),
+			wantsOpts: ImportOptions{
+				Indice:             "index",
+				ForwardToReplicas:  true,
+				ClearExistingRules: false,
+			},
+		},
+		{
+			name: "forward to replicas",
+			cli:  fmt.Sprintf("index -F %s -f=false", file),
+			wantsOpts: ImportOptions{
+				Indice:             "index",
+				ForwardToReplicas:  false,
+				ClearExistingRules: false,
+			},
+		},
+		{
+			name:     "replace existing rules, no --confirm, no TTY",
+			tty:      false,
+			cli:      fmt.Sprintf("index -F %s -c", file),
+			wantsErr: true,
+		},
+		{
+			name: "clear existing rules, --confirm, no TTY",
+			tty:  false,
+			cli:  fmt.Sprintf("index -F %s -c --confirm", file),
+			wantsOpts: ImportOptions{
+				Indice:             "index",
+				ForwardToReplicas:  true,
+				ClearExistingRules: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, _, _ := iostreams.Test()
+			if tt.tty {
+				io.SetStdinTTY(tt.tty)
+				io.SetStdoutTTY(tt.tty)
+			}
+
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+
+			var opts *ImportOptions
+			cmd := NewImportCmd(f, func(o *ImportOptions) error {
+				opts = o
+				return nil
+			})
+
+			args, err := shlex.Split(tt.cli)
+			require.NoError(t, err)
+			cmd.SetArgs(args)
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantsOpts.Indice, opts.Indice)
+			assert.Equal(t, tt.wantsOpts.ForwardToReplicas, opts.ForwardToReplicas)
+			assert.Equal(t, tt.wantsOpts.ClearExistingRules, opts.ClearExistingRules)
+		})
+	}
+}
 
 func Test_runExportCmd(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "rules.json")
@@ -54,7 +149,7 @@ func Test_runExportCmd(t *testing.T) {
 			defer r.Verify(t)
 
 			f, out := test.NewFactory(true, &r, nil, tt.stdin)
-			cmd := NewImportCmd(f)
+			cmd := NewImportCmd(f, nil)
 			out, err := test.Execute(cmd, tt.cli, out)
 			if err != nil {
 				assert.EqualError(t, err, tt.wantErr)

--- a/pkg/cmd/rules/rules.go
+++ b/pkg/cmd/rules/rules.go
@@ -17,7 +17,7 @@ func NewRulesCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:   "Manage your Algolia rules",
 	}
 
-	cmd.AddCommand(importRules.NewImportCmd(f))
+	cmd.AddCommand(importRules.NewImportCmd(f, nil))
 	cmd.AddCommand(browse.NewBrowseCmd(f))
 	cmd.AddCommand(delete.NewDeleteCmd(f, nil))
 

--- a/pkg/cmd/settings/set/set.go
+++ b/pkg/cmd/settings/set/set.go
@@ -40,7 +40,7 @@ func NewSetCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Set the settings of the specified index.",
 		Example: heredoc.Doc(`
 			# Set the typo tolerance to false on the PRODUCTS index
-			$ settings set PRODUCTS --typoTolerance="false"
+			$ algolia settings set PRODUCTS --typoTolerance="false"
 		`),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/synonyms/browse/browse.go
+++ b/pkg/cmd/synonyms/browse/browse.go
@@ -39,10 +39,10 @@ func NewBrowseCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:             "List all the the synonyms of the given index",
 		Example: heredoc.Doc(`
 			# List all the synonyms of the 'TEST_PRODUCTS_1' index
-			$ algolia synonym browse TEST_PRODUCTS_1
+			$ algolia synonyms browse TEST_PRODUCTS_1
 
 			# List all the synonyms of the 'TEST_PRODUCTS_1' and save them to the 'synonyms.json' file
-			$ algolia synonym browse TEST_PRODUCTS_1 > synonyms.json
+			$ algolia synonyms browse TEST_PRODUCTS_1 > synonyms.json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Indice = args[0]

--- a/pkg/cmd/synonyms/import/import.go
+++ b/pkg/cmd/synonyms/import/import.go
@@ -38,14 +38,14 @@ func NewImportCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:               "import <index> -F <file>",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: cmdutil.IndexNames(opts.SearchClient),
-		Short:             "Import synonyms to the indice",
+		Short:             "Import synonyms to the index",
 		Long: heredoc.Doc(`
-			Import synonyms to the provided indice.
+			Import synonyms to the provided index.
 			The file must contains one single JSON synonym per line (newline delimited JSON objects - ndjson format: https://ndjson.org/).
 		`),
 		Example: heredoc.Doc(`
 			# Import synonyms from the "synonyms.ndjson" file to the "TEST_PRODUCTS_1" index
-			$ algolia import TEST_PRODUCTS_1 -F synonyms.ndjson
+			$ algolia synonyms import TEST_PRODUCTS_1 -F synonyms.ndjson
 
 			# Import objects from the standard input to the "TEST_PRODUCTS_1" index
 			$ cat synonyms.ndjson | algolia synonyms import TEST_PRODUCTS_1 -F -

--- a/pkg/cmd/synonyms/import/import_test.go
+++ b/pkg/cmd/synonyms/import/import_test.go
@@ -7,12 +7,100 @@ import (
 	"testing"
 
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/algolia/cli/pkg/cmdutil"
 	"github.com/algolia/cli/pkg/httpmock"
+	"github.com/algolia/cli/pkg/iostreams"
 	"github.com/algolia/cli/test"
 )
+
+func TestNewImportCmd(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "synonyms.ndjson")
+	_ = ioutil.WriteFile(file, []byte("{\"objectID\":\"test\", \"type\": \"synonym\", \"synonyms\": [\"test\"]}"), 0600)
+
+	tests := []struct {
+		name      string
+		tty       bool
+		cli       string
+		wantsErr  bool
+		wantsOpts ImportOptions
+	}{
+		{
+			name:     "no file specified",
+			cli:      "index",
+			wantsErr: true,
+		},
+		{
+			name:     "file not found",
+			cli:      "index --file not-found",
+			wantsErr: true,
+		},
+		{
+			name: "file specified",
+			cli:  fmt.Sprintf("index -F %s", file),
+			wantsOpts: ImportOptions{
+				Index:                   "index",
+				ForwardToReplicas:       true,
+				ReplaceExistingSynonyms: false,
+			},
+		},
+		{
+			name: "forward to replicas",
+			cli:  fmt.Sprintf("index -F %s -f=false", file),
+			wantsOpts: ImportOptions{
+				Index:                   "index",
+				ForwardToReplicas:       false,
+				ReplaceExistingSynonyms: false,
+			},
+		},
+		{
+			name: "replace existing synonyms",
+			cli:  fmt.Sprintf("index -F %s -r=true", file),
+			wantsOpts: ImportOptions{
+				Index:                   "index",
+				ForwardToReplicas:       true,
+				ReplaceExistingSynonyms: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, _, _ := iostreams.Test()
+			if tt.tty {
+				io.SetStdinTTY(tt.tty)
+				io.SetStdoutTTY(tt.tty)
+			}
+
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+
+			var opts *ImportOptions
+			cmd := NewImportCmd(f, func(o *ImportOptions) error {
+				opts = o
+				return nil
+			})
+
+			args, err := shlex.Split(tt.cli)
+			require.NoError(t, err)
+			cmd.SetArgs(args)
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantsOpts.Index, opts.Index)
+			assert.Equal(t, tt.wantsOpts.ForwardToReplicas, opts.ForwardToReplicas)
+			assert.Equal(t, tt.wantsOpts.ReplaceExistingSynonyms, opts.ReplaceExistingSynonyms)
+		})
+	}
+}
 
 func Test_runExportCmd(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "synonyms.json")
@@ -43,6 +131,16 @@ func Test_runExportCmd(t *testing.T) {
 			stdin:   `{"objectID", "test"},`,
 			wantErr: "failed to parse JSON synonym on line 0: invalid character ',' after object key",
 		},
+		{
+			name:    "from file with forward to replicas",
+			cli:     fmt.Sprintf("foo -F '%s' -f", tmpFile),
+			wantOut: "✓ Successfully imported 1 synonyms to foo\n",
+		},
+		{
+			name:    "from file with replace existing synonyms",
+			cli:     fmt.Sprintf("foo -F '%s' -r", tmpFile),
+			wantOut: "✓ Successfully imported 1 synonyms to foo\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -54,7 +152,7 @@ func Test_runExportCmd(t *testing.T) {
 			defer r.Verify(t)
 
 			f, out := test.NewFactory(true, &r, nil, tt.stdin)
-			cmd := NewImportCmd(f)
+			cmd := NewImportCmd(f, nil)
 			out, err := test.Execute(cmd, tt.cli, out)
 			if err != nil {
 				assert.EqualError(t, err, tt.wantErr)

--- a/pkg/cmd/synonyms/synonyms.go
+++ b/pkg/cmd/synonyms/synonyms.go
@@ -17,7 +17,7 @@ func NewSynonymsCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:   "Manage your Algolia synonyms",
 	}
 
-	cmd.AddCommand(importSynonyms.NewImportCmd(f))
+	cmd.AddCommand(importSynonyms.NewImportCmd(f, nil))
 	cmd.AddCommand(browse.NewBrowseCmd(f))
 	cmd.AddCommand(delete.NewDeleteCmd(f, nil))
 


### PR DESCRIPTION
This PR fixes some typos and forgotten words in the 'Examples' and 'Usage' messages.